### PR TITLE
Upgrade Prisma to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@nrwl/next": "13.3.9",
-        "@prisma/client": "^3.6.0",
+        "@prisma/client": "5.0.0",
         "axios": "0.24.0",
         "core-js": "^3.6.5",
         "express": "4.17.2",
@@ -55,7 +55,7 @@
         "eslint-plugin-react-hooks": "4.2.0",
         "jest": "27.2.3",
         "prettier": "2.5.1",
-        "prisma": "^3.6.0",
+        "prisma": "5.0.0",
         "react-test-renderer": "17.0.2",
         "ts-jest": "27.0.5",
         "typescript": "~4.4.3"
@@ -3776,15 +3776,15 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.6.0.tgz",
-      "integrity": "sha512-ycSGY9EZGROtje0iCNsgC5Zqi/ttX2sO7BNMYaLsUMiTlf3F69ZPH+08pRo0hrDfkZzyimXYqeXJlaoYDH1w7A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.0.0.tgz",
+      "integrity": "sha512-XlO5ELNAQ7rV4cXIDJUNBEgdLwX3pjtt9Q/RHqDpGf43szpNJx2hJnggfFs7TKNx0cOFsl6KJCSfqr5duEU/bQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines-version": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727"
+        "@prisma/engines-version": "4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584"
       },
       "engines": {
-        "node": ">=12.6"
+        "node": ">=16.13"
       },
       "peerDependencies": {
         "prisma": "*"
@@ -3796,16 +3796,16 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727.tgz",
-      "integrity": "sha512-dRClHS7DsTVchDKzeG72OaEyeDskCv91pnZ72Fftn0mp4BkUvX2LvWup65hCNzwwQm5IDd6A88APldKDnMiEMA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.0.0.tgz",
+      "integrity": "sha512-kyT/8fd0OpWmhAU5YnY7eP31brW1q1YrTGoblWrhQJDiN/1K+Z8S1kylcmtjqx5wsUGcP1HBWutayA/jtyt+sg==",
       "devOptional": true,
       "hasInstallScript": true
     },
     "node_modules/@prisma/engines-version": {
-      "version": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727.tgz",
-      "integrity": "sha512-vtoO2ys6mSfc8ONTWdcYztKN3GBU1tcKBj0aXObyjzSuGwHFcM/pEA0xF+n1W4/0TAJgfoPX2khNEit6g0jtNA=="
+      "version": "4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584.tgz",
+      "integrity": "sha512-HHiUF6NixsldsP3JROq07TYBLEjXFKr6PdH8H4gK/XAoTmIplOJBCgrIUMrsRAnEuGyRoRLXKXWUb943+PFoKQ=="
     },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.0",
@@ -15743,20 +15743,19 @@
       }
     },
     "node_modules/prisma": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-3.6.0.tgz",
-      "integrity": "sha512-6SqgHS/5Rq6HtHjsWsTxlj+ySamGyCLBUQfotc2lStOjPv52IQuDVpp58GieNqc9VnfuFyHUvTZw7aQB+G2fvQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.0.0.tgz",
+      "integrity": "sha512-KYWk83Fhi1FH59jSpavAYTt2eoMVW9YKgu8ci0kuUnt6Dup5Qy47pcB4/TLmiPAbhGrxxSz7gsSnJcCmkyPANA==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727"
+        "@prisma/engines": "5.0.0"
       },
       "bin": {
-        "prisma": "build/index.js",
-        "prisma2": "build/index.js"
+        "prisma": "build/index.js"
       },
       "engines": {
-        "node": ">=12.6"
+        "node": ">=16.13"
       }
     },
     "node_modules/process": {
@@ -22220,23 +22219,23 @@
       }
     },
     "@prisma/client": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.6.0.tgz",
-      "integrity": "sha512-ycSGY9EZGROtje0iCNsgC5Zqi/ttX2sO7BNMYaLsUMiTlf3F69ZPH+08pRo0hrDfkZzyimXYqeXJlaoYDH1w7A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.0.0.tgz",
+      "integrity": "sha512-XlO5ELNAQ7rV4cXIDJUNBEgdLwX3pjtt9Q/RHqDpGf43szpNJx2hJnggfFs7TKNx0cOFsl6KJCSfqr5duEU/bQ==",
       "requires": {
-        "@prisma/engines-version": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727"
+        "@prisma/engines-version": "4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584"
       }
     },
     "@prisma/engines": {
-      "version": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727.tgz",
-      "integrity": "sha512-dRClHS7DsTVchDKzeG72OaEyeDskCv91pnZ72Fftn0mp4BkUvX2LvWup65hCNzwwQm5IDd6A88APldKDnMiEMA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.0.0.tgz",
+      "integrity": "sha512-kyT/8fd0OpWmhAU5YnY7eP31brW1q1YrTGoblWrhQJDiN/1K+Z8S1kylcmtjqx5wsUGcP1HBWutayA/jtyt+sg==",
       "devOptional": true
     },
     "@prisma/engines-version": {
-      "version": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727.tgz",
-      "integrity": "sha512-vtoO2ys6mSfc8ONTWdcYztKN3GBU1tcKBj0aXObyjzSuGwHFcM/pEA0xF+n1W4/0TAJgfoPX2khNEit6g0jtNA=="
+      "version": "4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584.tgz",
+      "integrity": "sha512-HHiUF6NixsldsP3JROq07TYBLEjXFKr6PdH8H4gK/XAoTmIplOJBCgrIUMrsRAnEuGyRoRLXKXWUb943+PFoKQ=="
     },
     "@rollup/plugin-babel": {
       "version": "5.3.0",
@@ -31345,12 +31344,12 @@
       "dev": true
     },
     "prisma": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-3.6.0.tgz",
-      "integrity": "sha512-6SqgHS/5Rq6HtHjsWsTxlj+ySamGyCLBUQfotc2lStOjPv52IQuDVpp58GieNqc9VnfuFyHUvTZw7aQB+G2fvQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.0.0.tgz",
+      "integrity": "sha512-KYWk83Fhi1FH59jSpavAYTt2eoMVW9YKgu8ci0kuUnt6Dup5Qy47pcB4/TLmiPAbhGrxxSz7gsSnJcCmkyPANA==",
       "devOptional": true,
       "requires": {
-        "@prisma/engines": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727"
+        "@prisma/engines": "5.0.0"
       }
     },
     "process": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "private": true,
   "dependencies": {
     "@nrwl/next": "13.3.9",
-    "@prisma/client": "^3.6.0",
+    "@prisma/client": "5.0.0",
     "axios": "0.24.0",
     "core-js": "^3.6.5",
     "express": "4.17.2",
@@ -57,7 +57,7 @@
     "eslint-plugin-react-hooks": "4.2.0",
     "jest": "27.2.3",
     "prettier": "2.5.1",
-    "prisma": "^3.6.0",
+    "prisma": "5.0.0",
     "react-test-renderer": "17.0.2",
     "ts-jest": "27.0.5",
     "typescript": "~4.4.3"


### PR DESCRIPTION
Hi @jacksloan, do you have interest in using the latest version? It supports [interactive transactions](https://www.prisma.io/docs/concepts/components/prisma-client/transactions) out of the box. I would love to use the feature but right now I'm getting an error after upgrading some local projects: `TypeError: this.prisma.$transaction is not a function`

I ran it locally and it seems to work:
<img width="279" alt="firefox_Ypf0EiC8iz" src="https://github.com/jacksloan/prisma-proxy/assets/1226564/c65cea22-46c2-413d-9c29-53167cba186c">
![image](https://github.com/jacksloan/prisma-proxy/assets/1226564/ad8ec505-c6b6-4cd5-9ef6-cdefe2f188bc)


One caveat is I had to `npm install -f ` locally because I ran into some dependency errors like in CI here: https://github.com/jacksloan/prisma-proxy/actions/runs/5582307934/jobs/10201455026?pr=12#step:4:12